### PR TITLE
Make Remote-Base-Directory functional for server

### DIFF
--- a/pkg/client/ftp_test.go
+++ b/pkg/client/ftp_test.go
@@ -31,6 +31,7 @@ func launchWebserverFTP() error {
 	lgr := gravlog.New(discarder{})
 
 	cfg := ftpstore.FtpStoreConfig{
+		BaseDir:    "testing",
 		LocalStore: localStoreDir,
 		FtpServer:  "127.0.0.1:2000",
 		Username:   "gravwell",

--- a/pkg/webserver/webserver.go
+++ b/pkg/webserver/webserver.go
@@ -66,7 +66,7 @@ func NewWebserver(conf WebserverConfig) (*Webserver, error) {
 	var err error
 	var config *tls.Config
 	if !conf.DisableTLS {
-		config := &tls.Config{
+		config = &tls.Config{
 			MinVersion:               tls.VersionTLS12,
 			PreferServerCipherSuites: true,
 			CipherSuites: []uint16{

--- a/server/server.go
+++ b/server/server.go
@@ -67,6 +67,7 @@ func main() {
 		fcfg := ftpstore.FtpStoreConfig{
 			LocalStore: cfg.Global.Storage_Directory,
 			FtpServer:  cfg.Global.FTP_Server,
+			BaseDir:    cfg.Global.Remote_Base_Directory,
 			Username:   cfg.Global.FTP_Username,
 			Password:   cfg.Global.FTP_Password,
 			Lgr:        lgr,


### PR DESCRIPTION
Properly uses the Remote-Base-Directory to set the target location for files on the FTP backend, e.g. if you set `Remote-Base-Directory=gravwell`, your uploaded shards will go to `/home/<username>/gravwell/` instead of just `/home/<username>/`

Addresses #6
