### PR TITLE
adding close method to handler interface

### DIFF
--- a/pkg/filestore/filestore.go
+++ b/pkg/filestore/filestore.go
@@ -53,6 +53,10 @@ func (f *filestore) Preflight() (err error) {
 	return
 }
 
+func (f *filestore) Close() (err error) {
+	return
+}
+
 func (f *filestore) ListIndexes(cid uint64) ([]string, error) {
 	var idx []string
 	custDir := filepath.Join(f.basedir, strconv.FormatUint(cid, 10))

--- a/pkg/ftpstore/ftpstore.go
+++ b/pkg/ftpstore/ftpstore.go
@@ -79,6 +79,10 @@ func (f *ftpstore) Preflight() (err error) {
 	return
 }
 
+func (f *ftpstore) Close() (err error) {
+	return
+}
+
 func (f *ftpstore) getFtpClient() (*ftp.ServerConn, error) {
 	do := ftp.DialWithTimeout(10 * time.Second)
 	c, err := ftp.Dial(f.cfg.FtpServer, do)

--- a/pkg/webserver/shards.go
+++ b/pkg/webserver/shards.go
@@ -29,6 +29,7 @@ var (
 
 type ShardHandler interface {
 	Preflight() error
+	Close() error
 	UnpackShard(cid uint64, guid uuid.UUID, well, shard string, rdr io.Reader) error
 	PackShard(cid uint64, guid uuid.UUID, well, shard string, wtr io.Writer) error
 	ListIndexes(cid uint64) ([]string, error)
@@ -133,6 +134,10 @@ type HashHandler struct {
 }
 
 func (hh *HashHandler) Preflight() (err error) {
+	return
+}
+
+func (hh *HashHandler) Close() (err error) {
 	return
 }
 

--- a/pkg/webserver/webserver.go
+++ b/pkg/webserver/webserver.go
@@ -246,6 +246,7 @@ func (w *Webserver) buildRequestRouter() error {
 
 	// Handler to get back a list of tags for the indexer
 	w.m.PathPrefix(TAG_PATH).Handler(authChain.Handler(w.indexerGetTags)).Methods(http.MethodGet)
+
 	// Handler to let an indexer update its tag set
 	w.m.PathPrefix(TAG_PATH).Handler(authChain.Handler(w.indexerSyncTags)).Methods(http.MethodPost)
 


### PR DESCRIPTION
This PR addresses no issue

It just adds a `Close` method on our interface and two implemented handlers so that other handlers that need a shutdown can do so.